### PR TITLE
atcab: handle 'Watchdog About to Exprire' properly

### DIFF
--- a/lib/atca_command.c
+++ b/lib/atca_command.c
@@ -1153,6 +1153,9 @@ ATCA_STATUS isATCAError(uint8_t *data)
         case 0xff: // bad crc found (command not properly received by device) or other comm error
             return ATCA_STATUS_CRC;
             break;
+        case 0xee: // watchdog is almost expired, need to reset watchdog
+            return ATCA_STATUS_WATCHDOG;
+            break;
         default:
             return ATCA_GEN_FAIL;
             break;

--- a/lib/atca_status.h
+++ b/lib/atca_status.h
@@ -54,6 +54,7 @@ typedef enum
     ATCA_STATUS_UNKNOWN         = 0xD5, //!< response status byte is unknown
     ATCA_STATUS_ECC             = 0xD6, //!< response status byte is ECC fault (status byte = 0x05)
     ATCA_STATUS_SELFTEST_ERROR  = 0xD7, //!< response status byte is Self Test Error, chip in failure mode (status byte = 0x07)
+    ATCA_STATUS_WATCHDOG        = 0xD8, //!< response status byte is Watchdog About to Expire (status byte = 0xEE)
     ATCA_FUNC_FAIL              = 0xE0, //!< Function could not execute due to incorrect condition / state.
     ATCA_GEN_FAIL               = 0xE1, //!< unspecified error
     ATCA_BAD_PARAM              = 0xE2, //!< bad argument (out of range, null pointer, etc.)

--- a/lib/basic/atca_basic.c
+++ b/lib/basic/atca_basic.c
@@ -402,12 +402,20 @@ ATCA_STATUS atcab_execute_command(ATCAPacket* packet)
     ATCACommand ca_cmd = _gDevice->mCommands;
     ATCAIface ca_iface = _gDevice->mIface;
 
+    // repeat flag for Watchdog About to Expire events
+    int do_full_repeat = 0;
+    int full_repeat_counter = MAX_OPERATION_RETRIES;
+
+    uint8_t recv_buffer[sizeof(packet->data)];
+
     if ((status = atGetExecTime(packet->opcode, ca_cmd)) != ATCA_SUCCESS)
     {
         return status;
     }
     do
     {
+        do_full_repeat = 0;
+
         if ((status = atcab_wakeup()) != ATCA_SUCCESS)
         {
             break;
@@ -425,7 +433,7 @@ ATCA_STATUS atcab_execute_command(ATCAPacket* packet)
             // delay the appropriate amount of time for command to execute
             atca_delay_ms(ca_cmd->execution_time_msec);
 
-            status = atreceive(ca_iface, packet->data, &(packet->rxsize));
+            status = atreceive(ca_iface, recv_buffer, &(packet->rxsize));
 
             // COMM_FAIL may mean that operation is not done yet
             if (status == ATCA_COMM_FAIL)
@@ -461,17 +469,33 @@ ATCA_STATUS atcab_execute_command(ATCAPacket* packet)
         }
 
 
-        if ((status = atCheckCrc(packet->data)) != ATCA_SUCCESS)
+        if ((status = atCheckCrc(recv_buffer)) != ATCA_SUCCESS)
         {
             break;
         }
 
-        if ((status = isATCAError(packet->data)) != ATCA_SUCCESS)
+        if ((status = isATCAError(recv_buffer)) != ATCA_SUCCESS)
         {
-            break;
+            if (status == ATCA_STATUS_WATCHDOG)
+            {
+                // Watchdog is about to expire, so need to set device to Idle mode and repeat
+                if (full_repeat_counter-- > 0)
+                {
+                    if ((status = atcab_idle()) != ATCA_SUCCESS)
+                    {
+                        break;
+                    }
+                    do_full_repeat = 1;
+                }
+
+            } else {
+                break;
+            }
         }
     }
-    while (0);
+    while (do_full_repeat);
+
+    memcpy(packet->data, recv_buffer, packet->rxsize);
 
     _atcab_exit();
     return status;


### PR DESCRIPTION
ATECC device may send 0xEE error code if its watchdog
is about to expire. This code was not handled properly
and ATCA_GEN_FAIL status code was returned. 

This patch enables reporting and handling of this condition
by sending device to idle mode and waking up again.